### PR TITLE
Updates to pass all 21 Webmention Rocks! tests

### DIFF
--- a/lib/webmention/client.rb
+++ b/lib/webmention/client.rb
@@ -132,8 +132,8 @@ module Webmention
 
     def self.discover_webmention_endpoint_from_html html
       doc = Nokogiri::HTML(html)
-      if !doc.css('[rel="webmention"]').empty?
-        doc.css('[rel="webmention"]').attribute("href").value
+      if !doc.css('[rel~="webmention"]').empty?
+        doc.css('[rel~="webmention"]').attribute("href").value
       elsif !doc.css('[rel="http://webmention.org/"]').empty?
         doc.css('[rel="http://webmention.org/"]').attribute("href").value
       elsif !doc.css('[rel="http://webmention.org"]').empty?

--- a/lib/webmention/client.rb
+++ b/lib/webmention/client.rb
@@ -144,11 +144,11 @@ module Webmention
     end
 
     def self.discover_webmention_endpoint_from_header header
-      if matches = header.match(%r{<([^>]+)>; rel="webmention"})
+      if matches = header.match(%r{<([^>]+)>; rel="[^"]*\s?webmention\s?[^"]*"})
         return matches[1]
       elsif matches = header.match(%r{<([^>]+)>; rel=webmention})
           return matches[1]
-      elsif matches = header.match(%r{rel="webmention"; <([^>]+)>})
+      elsif matches = header.match(%r{rel="[^"]*\s?webmention\s?[^"]*"; <([^>]+)>})
         return matches[1]
       elsif matches = header.match(%r{rel=webmention; <([^>]+)>})
         return matches[1]

--- a/lib/webmention/client.rb
+++ b/lib/webmention/client.rb
@@ -69,6 +69,9 @@ module Webmention
         :target => target,
       }
 
+      # Ensure the endpoint is an absolute URL
+      endpoint = absolute_endpoint endpoint, target
+
       begin
         response = HTTParty.post(endpoint, {
           :body => data
@@ -141,13 +144,17 @@ module Webmention
     end
 
     def self.discover_webmention_endpoint_from_header header
-      if matches = header.match(%r{<(https?://[^>]+)>; rel="webmention"})
+      if matches = header.match(%r{<([^>]+)>; rel="webmention"})
         return matches[1]
-      elsif matches = header.match(%r{rel="webmention"; <(https?://[^>]+)>})
+      elsif matches = header.match(%r{<([^>]+)>; rel=webmention})
+          return matches[1]
+      elsif matches = header.match(%r{rel="webmention"; <([^>]+)>})
         return matches[1]
-      elsif matches = header.match(%r{<(https?://[^>]+)>; rel="http://webmention\.org/?"})
+      elsif matches = header.match(%r{rel=webmention; <([^>]+)>})
         return matches[1]
-      elsif matches = header.match(%r{rel="http://webmention\.org/?"; <(https?://[^>]+)>})
+      elsif matches = header.match(%r{<([^>]+)>; rel="http://webmention\.org/?"})
+        return matches[1]
+      elsif matches = header.match(%r{rel="http://webmention\.org/?"; <([^>]+)>})
         return matches[1]
       end
       return false
@@ -164,6 +171,20 @@ module Webmention
       end
 
       return (url.is_a? URI::HTTP or url.is_a? URI::HTTPS)
+    end
+    
+    # Public: Takes an endpoint and ensures an absolute URL is returned
+    #
+    # endpoint - Endpoint which may be an absolute or relative URL
+    # url - URL of the webmention
+    #
+    # Returns original endpoint if it is already an absolute URL; constructs
+    # new absolute URL using relative endpoint if not 
+    def self.absolute_endpoint endpoint, url
+      unless Webmention::Client.valid_http_url? endpoint
+        endpoint = URI.join(url, endpoint).to_s
+      end
+      endpoint
     end
   end
 end

--- a/test/data/sample_html.rb
+++ b/test/data/sample_html.rb
@@ -113,4 +113,13 @@ class SampleData
     eos
   end
 
+  def self.empty_link_tag_no_href
+    <<-eos
+      <html>
+        <head>
+          <link href="" rel="webmention">
+        </head>
+      </html>
+    eos
+  end
 end

--- a/test/data/sample_html.rb
+++ b/test/data/sample_html.rb
@@ -102,5 +102,15 @@ class SampleData
       </html>
     eos
   end
+  
+  def self.link_tag_multiple_rel_values
+    <<-eos
+      <html>
+        <head>
+          <link href="http://webmention.io/example/webmention" rel="webmention foo bar">
+        </head>
+      </html>
+    eos
+  end
 
 end

--- a/test/data/sample_html.rb
+++ b/test/data/sample_html.rb
@@ -82,5 +82,25 @@ class SampleData
       </html>
     eos
   end
+  
+  def self.rel_webmention_relative_with_path
+    <<-eos
+      <html>
+        <head>
+          <link href="/example/webmention" rel="webmention">
+        </head>
+      </html>
+    eos
+  end
+
+  def self.rel_webmention_relative_without_path
+    <<-eos
+      <html>
+        <head>
+          <link href="webmention.php" rel="webmention">
+        </head>
+      </html>
+    eos
+  end
 
 end

--- a/test/lib/webmention/discovery_test.rb
+++ b/test/lib/webmention/discovery_test.rb
@@ -115,6 +115,10 @@ describe Webmention::Client do
     it "should find webmention in a link header among multiple rel values" do
       Webmention::Client.discover_webmention_endpoint_from_header('<http://webmention.io/example/webmention>; rel="webmention foo bar"').must_equal "http://webmention.io/example/webmention"
     end
+
+    it "should find rel=webmention in a link tag with an empty href" do
+      Webmention::Client.discover_webmention_endpoint_from_html(SampleData.empty_link_tag_no_href).must_equal ""
+    end
   end
 
 end

--- a/test/lib/webmention/discovery_test.rb
+++ b/test/lib/webmention/discovery_test.rb
@@ -107,6 +107,10 @@ describe Webmention::Client do
     it "should find rel=webmention followed by relative href without path in html" do
       Webmention::Client.discover_webmention_endpoint_from_html(SampleData.rel_webmention_relative_without_path).must_equal "webmention.php"
     end
+    
+    it "should find webmention in a link tag among multiple rel values" do
+      Webmention::Client.discover_webmention_endpoint_from_html(SampleData.link_tag_multiple_rel_values).must_equal "http://webmention.io/example/webmention"
+    end 
   end
 
 end

--- a/test/lib/webmention/discovery_test.rb
+++ b/test/lib/webmention/discovery_test.rb
@@ -110,7 +110,11 @@ describe Webmention::Client do
     
     it "should find webmention in a link tag among multiple rel values" do
       Webmention::Client.discover_webmention_endpoint_from_html(SampleData.link_tag_multiple_rel_values).must_equal "http://webmention.io/example/webmention"
-    end 
+    end
+    
+    it "should find webmention in a link header among multiple rel values" do
+      Webmention::Client.discover_webmention_endpoint_from_header('<http://webmention.io/example/webmention>; rel="webmention foo bar"').must_equal "http://webmention.io/example/webmention"
+    end
   end
 
 end

--- a/test/lib/webmention/discovery_test.rb
+++ b/test/lib/webmention/discovery_test.rb
@@ -36,12 +36,20 @@ describe Webmention::Client do
   end
 
   describe "#discover_webmention_endpoint_from_string" do
-    it "should find rel=webmention followed by href in header" do
+    it "should find rel=\"webmention\" followed by href in header" do
       Webmention::Client.discover_webmention_endpoint_from_header('rel="webmention"; <http://webmention.io/example/webmention>').must_equal "http://webmention.io/example/webmention"
     end
 
-    it "should find href followed by rel=webmention in header" do
+    it "should find rel=webmention followed by href in header" do
+      Webmention::Client.discover_webmention_endpoint_from_header('rel=webmention; <http://webmention.io/example/webmention>').must_equal "http://webmention.io/example/webmention"
+    end
+
+    it "should find href followed by rel=\"webmention\" in header" do
       Webmention::Client.discover_webmention_endpoint_from_header('<http://webmention.io/example/webmention>; rel="webmention"').must_equal "http://webmention.io/example/webmention"
+    end
+
+    it "should find href followed by rel=webmention in header" do
+      Webmention::Client.discover_webmention_endpoint_from_header('<http://webmention.io/example/webmention>; rel=webmention').must_equal "http://webmention.io/example/webmention"
     end
 
     it "should find rel=http://webmention.org followed by href in header" do
@@ -82,6 +90,22 @@ describe Webmention::Client do
 
     it "should find href followed by rel=http://webmention.org/ in html" do
       Webmention::Client.discover_webmention_endpoint_from_html(SampleData.rel_href_webmention_org_slash).must_equal "http://webmention.io/example/webmention"
+    end
+    
+    it "should find rel=webmention followed by relative href with path in header" do
+      Webmention::Client.discover_webmention_endpoint_from_header('</example/webmention>; rel="http://webmention.org"').must_equal "/example/webmention"
+    end
+
+    it "should find rel=webmention followed by relative href with path in html" do
+      Webmention::Client.discover_webmention_endpoint_from_html(SampleData.rel_webmention_relative_with_path).must_equal "/example/webmention"
+    end
+
+    it "should find rel=webmention followed by relative href without path in header" do
+      Webmention::Client.discover_webmention_endpoint_from_header('<webmention.php>; rel="http://webmention.org"').must_equal "webmention.php"
+    end
+
+    it "should find rel=webmention followed by relative href without path in html" do
+      Webmention::Client.discover_webmention_endpoint_from_html(SampleData.rel_webmention_relative_without_path).must_equal "webmention.php"
     end
   end
 

--- a/test/lib/webmention/url_test.rb
+++ b/test/lib/webmention/url_test.rb
@@ -37,5 +37,9 @@ describe Webmention::Client do
     it "should expand an endpoint url without a path to an absolute url based on the webmention url" do
       Webmention::Client.absolute_endpoint('webmention.php', 'http://webmention.io/example/1').must_equal "http://webmention.io/example/webmention.php"
     end
+
+    it "should take an empty endpoint url and return the webmention url" do
+      Webmention::Client.absolute_endpoint('', 'http://webmention.io/example/1').must_equal "http://webmention.io/example/1"
+    end
   end
 end

--- a/test/lib/webmention/url_test.rb
+++ b/test/lib/webmention/url_test.rb
@@ -28,4 +28,14 @@ describe Webmention::Client do
       end
     end
   end
+  
+  describe "#absolute_endpoint" do
+    it "should expand an endpoint url with a path to an absolute url based on the webmention url" do
+      Webmention::Client.absolute_endpoint('/webmention', 'http://webmention.io/example/1').must_equal "http://webmention.io/webmention"
+    end
+
+    it "should expand an endpoint url without a path to an absolute url based on the webmention url" do
+      Webmention::Client.absolute_endpoint('webmention.php', 'http://webmention.io/example/1').must_equal "http://webmention.io/example/webmention.php"
+    end
+  end
 end


### PR DESCRIPTION
Adds support for webmention endpoints with relative URLs and also allows use of (unquoted) `rel=webmention` in `Link` headers.

I use the gem in [my site](https://barryfrost.com) and webmentions were failing to reach https://webmention.rocks/test/1 which required both these changes.
