### PR TITLE
Fix Travis build errors and bump gem version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.3
-  - 2.0.0
-  - 1.9.3
+  - 2.2.7
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 rvm:
+  - 2.4.1
+  - 2.3.4
   - 2.2.7
 notifications:
   email: false

--- a/lib/webmention/version.rb
+++ b/lib/webmention/version.rb
@@ -1,3 +1,3 @@
 module Webmention
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/webmention.gemspec
+++ b/webmention.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'httparty', '~> 0.13.1'
   s.add_dependency 'link_header', '~> 0.0.8'
 
-  s.add_development_dependency 'bundler', '~> 1.3'
+  s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'webmock'


### PR DESCRIPTION
Following my #4 PR the tests were failing to run in Travis. This fixes the build errors by removing the dependency for an old version of Bundler and removing builds for older versions of Ruby. 

Nokogiri requires Ruby >= 2.1.0 so I've removed older Rubies in the Travis config file.

Finally, this bumps the gem version to 0.1.6.